### PR TITLE
Add meta descriptions

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VITE_BACKEND_API_BASE=http://localhost:5020
+BASE_URL=http://localhost:3000

--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,2 @@
 VITE_BACKEND_API_BASE=https://api.ficsit.app
+BASE_URL=https://ficsit.app

--- a/.env.staging
+++ b/.env.staging
@@ -1,1 +1,2 @@
 VITE_BACKEND_API_BASE=https://api.ficsit.dev
+BASE_URL=https://ficsit.dev

--- a/src/lib/components/utils/MetaDescriptors.svelte
+++ b/src/lib/components/utils/MetaDescriptors.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import {page} from '$app/stores';
+    import {base} from '$app/paths';
+    
+    let baseUrl = $page.host;
+    let route = $page.path;
+
+    export let description : string;
+    export let image : string;
+    export let title : string;
+</script>
+
+{#if description}
+    <meta property="description" content="{description}" />
+    <meta property="og:description" content="{description}" />
+{/if}
+
+{#if image}
+    <meta property="og:image" content="{image}" />
+{:else}
+    <meta property="og:image" content="{base}/assets/favicon.ico" />
+{/if}
+
+{#if title}
+    <title>{title} - SMR</title>
+    <meta property="og:title" content="{title} - SMR" />
+{/if}
+
+<meta property="og:url" content="{baseUrl}{route}" />

--- a/src/routes/about/index.svelte
+++ b/src/routes/about/index.svelte
@@ -1,9 +1,13 @@
 <svelte:head>
-  <title>About - SMR</title>
+  <MetaDescriptors 
+    description="About the Satisfactory Mod Repository" 
+    title="About" 
+  />
 </svelte:head>
 
 <script>
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 </script>
 
 <h1>About</h1>

--- a/src/routes/admin/index.svelte
+++ b/src/routes/admin/index.svelte
@@ -1,9 +1,13 @@
 <svelte:head>
-  <title>Admin - SMR</title>
+  <MetaDescriptors 
+    description="SMR Admin" 
+    title="Admin" 
+  />
 </svelte:head>
 
 <script>
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 </script>
 
 <h1>Admin Panel</h1>

--- a/src/routes/admin/sml-versions/[smlVersionId]/edit.svelte
+++ b/src/routes/admin/sml-versions/[smlVersionId]/edit.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Admin: Edit SML Version - SMR</title>
+  <MetaDescriptors 
+    description="Edit SML Version"
+    title="Admin: Edit SML Version" 
+  />
 </svelte:head>
 
 <script lang="ts" context="module">
@@ -16,6 +19,7 @@
   import type {SMLVersionData} from "$lib/models/sml-versions";
   import SMLVersionForm from "$lib/components/sml-versions/SMLVersionForm.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   export let smlVersionId!: string;
 

--- a/src/routes/admin/sml-versions/index.svelte
+++ b/src/routes/admin/sml-versions/index.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Admin: SML Versions - SMR</title>
+  <MetaDescriptors 
+    description="SML Versions"
+    title="Admin: SML Versions" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -8,6 +11,7 @@
   import {writable} from "svelte/store";
   import PageControls from "$lib/components/utils/PageControls.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   // TODO Selectable
   const perPage = 20;

--- a/src/routes/admin/sml-versions/new.svelte
+++ b/src/routes/admin/sml-versions/new.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Admin: New SML Version - SMR</title>
+  <MetaDescriptors 
+    description="New SML Version"
+    title="Admin: New SML Version" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -10,6 +13,7 @@
   import type {SMLVersionData} from "$lib/models/sml-versions";
   import SMLVersionForm from "$lib/components/sml-versions/SMLVersionForm.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   let errorMessage = '';
   let errorToast = false;

--- a/src/routes/admin/unapproved-mods.svelte
+++ b/src/routes/admin/unapproved-mods.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Admin: Unapproved Mods - SMR</title>
+  <MetaDescriptors 
+    description="Unapproved mods" 
+    title="Admin: Unapproved Mods" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -8,6 +11,7 @@
   import {writable} from "svelte/store";
   import PageControls from "$lib/components/utils/PageControls.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   // TODO Selectable
   const perPage = 20;

--- a/src/routes/admin/unapproved-versions.svelte
+++ b/src/routes/admin/unapproved-versions.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Admin: Unapproved Versions - SMR</title>
+  <MetaDescriptors 
+    description="Unapproved mod versions" 
+    title="Admin: Unapproved Versions" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -9,6 +12,7 @@
   import PageControls from "$lib/components/utils/PageControls.svelte";
   import {API_REST} from "$lib/core";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   // TODO Selectable
   const perPage = 20;

--- a/src/routes/api-docs/index.svelte
+++ b/src/routes/api-docs/index.svelte
@@ -1,9 +1,13 @@
 <svelte:head>
-  <title>API Docs - SMR</title>
+  <MetaDescriptors 
+    description="API documentation for the Satisfactory Mod Repository"
+    title="API Docs" 
+  />
 </svelte:head>
 
 <script lang="ts">
   import {API_GRAPHQL, API_GRAPHQL_PLAYGROUND, API_REST, API_REST_DOCS} from "$lib/core";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 </script>
 
 <h1>API Docs</h1>

--- a/src/routes/guide/[guideId]/edit.svelte
+++ b/src/routes/guide/[guideId]/edit.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$guide.fetching && !$guide.error && $guide.data.getGuide}
-    <title>{$guide.data.getGuide.name} - SMR</title>
+    <MetaDescriptors 
+      description="Editing guide '{$guide.data.getGuide.short_description}'"
+      title="Edit guide '{$guide.data.getGuide.name}'" 
+    />
   {/if}
 </svelte:head>
 
@@ -18,6 +21,7 @@
   import GuideForm from "$lib/components/guides/GuideForm.svelte";
   import type {GuideData} from "$lib/models/guides";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   export let guideId!: string;
 

--- a/src/routes/guide/[guideId]/index.svelte
+++ b/src/routes/guide/[guideId]/index.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$guide.fetching && !$guide.error && $guide.data.getGuide}
-    <title>Edit {$guide.data.getGuide.name} - SMR</title>
+    <MetaDescriptors 
+      description="{$guide.data.getGuide.short_description}"
+      title="{$guide.data.getGuide.name}" 
+    />
   {/if}
 </svelte:head>
 
@@ -9,6 +12,7 @@
   import {operationStore} from "@urql/svelte";
   import {GetGuideDocument} from "$lib/generated";
   import {loadWaitForNoFetch} from "$lib/utils/gql";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const guideQ = operationStore(
     GetGuideDocument,

--- a/src/routes/guides/index.svelte
+++ b/src/routes/guides/index.svelte
@@ -1,10 +1,14 @@
 <svelte:head>
-  <title>Guides - SMR</title>
+  <MetaDescriptors 
+    description="Guides for Satisfactory and modding Satisfactory"
+    title="Guides" 
+  />
 </svelte:head>
 
 <script lang="ts">
   import GuideGrid from "$lib/components/guides/GuideGrid.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 </script>
 
 <div class="flex justify-between items-center">

--- a/src/routes/help/index.svelte
+++ b/src/routes/help/index.svelte
@@ -1,10 +1,15 @@
 <svelte:head>
   <title>Help - SMR</title>
+  <MetaDescriptors 
+    description="Help for submitting modules to the Satsifactory Mod Repository"
+    title="Help" 
+    />
 </svelte:head>
 
 <script lang="ts">
   import {markdown} from '$lib/utils/markdown';
   import {validateUPluginJson} from "$lib/utils/uplugin";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const exampleUPluginJson = '```json\n' + JSON.stringify({
     "CanContainContent": true,

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Home - SMR</title>
+  <MetaDescriptors 
+    description="Satisfactory Mod Repository" 
+    title="Home" 
+  />
 </svelte:head>
 
 <script lang="ts" context="module">
@@ -34,6 +37,7 @@
   import ModGrid from "$lib/components/mods/ModGrid.svelte";
   import Footer from "$lib/components/general/Footer.svelte";
   import {goto} from '$app/navigation';
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   export let featuredMods!: typeof featuredModsQ;
   export let mods!: typeof modsQ;

--- a/src/routes/mod/[modId]/edit.svelte
+++ b/src/routes/mod/[modId]/edit.svelte
@@ -1,6 +1,10 @@
 <svelte:head>
   {#if !$mod.fetching && !$mod.error && $mod.data.getMod}
-    <title>Edit Mod: {$mod.data.getMod.name} - SMR</title>
+    <MetaDescriptors 
+      description="Editing mod {$mod.data.getMod.name}"
+      title="Edit mod {$mod.data.getMod.name}" 
+      image={$mod.data.getMod.logo}
+    />
   {/if}
 </svelte:head>
 
@@ -18,6 +22,7 @@
   import ModForm from "$lib/components/mods/ModForm.svelte";
   import type {ModData} from "$lib/models/mods";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   export let modId!: string;
 

--- a/src/routes/mod/[modId]/index.svelte
+++ b/src/routes/mod/[modId]/index.svelte
@@ -1,8 +1,10 @@
 <svelte:head>
   {#if !$mod.fetching && !$mod.error && $mod.data.getMod}
-    <title>{$mod.data.getMod.name} - SMR</title>
-    <meta property="og:image" content={$mod.data.getMod.logo} />
-    <meta property="og:description" content={$mod.data.getMod.short_description} />
+    <MetaDescriptors 
+      description={$mod.data.getMod.short_description}
+      title={$mod.data.getMod.name}
+      image={$mod.data.getMod.logo}
+    />
   {/if}
 </svelte:head>
 
@@ -11,6 +13,7 @@
   import {operationStore} from "@urql/svelte";
   import {GetModDocument} from "$lib/generated";
   import {loadWaitForNoFetch} from "$lib/utils/gql";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const modQ = operationStore(
     GetModDocument,

--- a/src/routes/mod/[modId]/new-version.svelte
+++ b/src/routes/mod/[modId]/new-version.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$mod.fetching && !$mod.error && $mod.data.getMod}
-    <title>New Version: {$mod.data.getMod.name} - SMR</title>
+    <MetaDescriptors 
+      description="Creating a new version of mod {$mod.data.getMod.name}"
+      title="New version of mod {$mod.data.getMod.name}" 
+  />
   {/if}
 </svelte:head>
 
@@ -27,6 +30,7 @@
   import {chunkedUpload} from "$lib/utils/chunked-upload";
   import type {UploadState} from "$lib/utils/chunked-upload";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   export let modId!: string;
 

--- a/src/routes/mod/[modId]/version/[versionId]/edit.svelte
+++ b/src/routes/mod/[modId]/version/[versionId]/edit.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$version.fetching && !$version.error && $version.data.getVersion}
-    <title>Edit {$version.data.getVersion.mod.name} {$version.data.getVersion.version} - SMR</title>
+    <MetaDescriptors 
+      description="Editing mod version {$version.data.getVersion.mod.name} {$version.data.getVersion.version}"
+      title="Edit mod version {$version.data.getVersion.mod.name} {$version.data.getVersion.version}" 
+    />
   {/if}
 </svelte:head>
 
@@ -18,6 +21,8 @@
   import VersionForm from "$lib/components/versions/VersionForm.svelte";
   import type {VersionData} from "$lib/models/versions";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
+
 
   export let modId!: string;
   export let versionId!: string;

--- a/src/routes/mod/[modId]/version/[versionId]/index.svelte
+++ b/src/routes/mod/[modId]/version/[versionId]/index.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$version.fetching && !$version.error && $version.data.getVersion}
-    <title>{$version.data.getVersion.mod.name} {$version.data.getVersion.version} - SMR</title>
+    <MetaDescriptors 
+      description="Information for mod version {$version.data.getVersion.mod.name} {$version.data.getVersion.version}"
+      title="Mod version {$version.data.getVersion.mod.name} {$version.data.getVersion.version}" 
+    />
   {/if}
 </svelte:head>
 
@@ -9,6 +12,7 @@
   import {operationStore} from "@urql/svelte";
   import {GetModVersionDocument} from "$lib/generated";
   import {loadWaitForNoFetch} from "$lib/utils/gql";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const versionQ = operationStore(
     GetModVersionDocument,

--- a/src/routes/mods/index.svelte
+++ b/src/routes/mods/index.svelte
@@ -1,10 +1,14 @@
 <svelte:head>
-  <title>Mods - SMR</title>
+  <MetaDescriptors 
+    description="Mods available from the Satisfactory Mod Repository"
+    title="Mods" 
+  />
 </svelte:head>
 
 <script lang="ts">
   import ModGrid from "$lib/components/mods/ModGrid.svelte";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 </script>
 
 <div class="flex justify-between items-center">

--- a/src/routes/new-guide/index.svelte
+++ b/src/routes/new-guide/index.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>New Guide - SMR</title>
+  <MetaDescriptors 
+    description="Creating a new guide"
+    title="New guide" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -10,6 +13,7 @@
   import GuideForm from "$lib/components/guides/GuideForm.svelte";
   import type {GuideData} from "$lib/models/guides";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   let errorMessage = '';
   let errorToast = false;

--- a/src/routes/new-mod/index.svelte
+++ b/src/routes/new-mod/index.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>New Mod - SMR</title>
+  <MetaDescriptors 
+    description="Adding a new mod in the Satisfactory Mod Repository"
+    title="New mod" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -10,6 +13,7 @@
   import ModForm from "$lib/components/mods/ModForm.svelte";
   import type {ModData} from "$lib/models/mods";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   let errorMessage = '';
   let errorToast = false;

--- a/src/routes/privacy-policy/index.svelte
+++ b/src/routes/privacy-policy/index.svelte
@@ -1,6 +1,13 @@
 <svelte:head>
-  <title>Privacy Policy - SMR</title>
+  <MetaDescriptors 
+    description="Privacy policy for the Satisfactory Mod Repository"
+    title="Privacy policy" 
+  />
 </svelte:head>
+
+<script lang="ts">
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
+</script>
 
 <div>
   <h1>Privacy Policy</h1>

--- a/src/routes/settings/index.svelte
+++ b/src/routes/settings/index.svelte
@@ -1,5 +1,8 @@
 <svelte:head>
-  <title>Settings - SMR</title>
+  <MetaDescriptors 
+      description="Change your user settings"
+      title="Settings" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -15,6 +18,7 @@
   import * as zod from "zod";
   import type {Form} from "@felte/core";
   import {base} from "$app/paths";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   let errorMessage = '';
   let errorToast = false;

--- a/src/routes/sml-versions/index.svelte
+++ b/src/routes/sml-versions/index.svelte
@@ -1,5 +1,9 @@
 <svelte:head>
   <title>SML Versions - SMR</title>
+  <MetaDescriptors 
+    description="Versions of the Satisfactory Mod Loader"
+    title="Satisfactory Mod Loader versions" 
+  />
 </svelte:head>
 
 <script lang="ts">
@@ -8,6 +12,7 @@
   import {writable} from "svelte/store";
   import PageControls from "$lib/components/utils/PageControls.svelte";
   import {markdown} from '$lib/utils/markdown';
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   let expandedVersions = new Set<string>();
 

--- a/src/routes/tools/index.svelte
+++ b/src/routes/tools/index.svelte
@@ -1,10 +1,15 @@
 <svelte:head>
   <title>Tools - SMR</title>
+  <MetaDescriptors 
+    description="A collection of useful tools for Satisfactory, such as recipe calculators and save editors"
+    title="Tools" 
+  />
 </svelte:head>
 
 <script lang="ts">
   import type {Tool} from "$lib/models/tools";
   import ToolCard from "$lib/components/tools/ToolCard.svelte";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const tools: Tool[] = [
     {

--- a/src/routes/tos/index.svelte
+++ b/src/routes/tos/index.svelte
@@ -1,6 +1,13 @@
 <svelte:head>
-  <title>Terms of Service - SMR</title>
+  <MetaDescriptors 
+    description="Terms of service for the Satisfactory Mod Repository"
+    title="Terms of service" 
+  />  
 </svelte:head>
+
+<script lang="ts">
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
+</script>
 
 <div>
   <h1>Terms of Service</h1>

--- a/src/routes/user/[userId]/index.svelte
+++ b/src/routes/user/[userId]/index.svelte
@@ -1,6 +1,9 @@
 <svelte:head>
   {#if !$user.fetching && !$user.error && $user.data.getUser}
-    <title>{$user.data.getUser.username} - SMR</title>
+    <MetaDescriptors 
+      description="{$user.data.getUser.username} profile"
+      title="{$user.data.getUser.username} profile" 
+    />
   {/if}
 </svelte:head>
 
@@ -9,6 +12,7 @@
   import {operationStore} from "@urql/svelte";
   import {GetUserDocument} from "$lib/generated";
   import {loadWaitForNoFetch} from "$lib/utils/gql";
+  import MetaDescriptors from "$lib/components/utils/MetaDescriptors.svelte";
 
   const userQ = operationStore(
     GetUserDocument,

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -36,6 +36,8 @@ const config = {
       fallback: 'index.html'
     }),
 
+    host: process.env.BASE_URL || 'http://localhost:3000',
+
     ssr: true,
 
     // hydrate the <div id="svelte"> element in src/app.html


### PR DESCRIPTION
Fixes #12 

Adds a new component that writes out the correct meta tags in a consistent way. Also introduces it on every page that needs it.
