### PR TITLE
Announcement headers

### DIFF
--- a/src/gql/announcement/announcements.graphql
+++ b/src/gql/announcement/announcements.graphql
@@ -1,0 +1,7 @@
+query GetAnnouncements {
+  getAnnouncements {
+    id
+    message
+    importance
+  }
+}

--- a/src/lib/components/announcements/AnnouncementHeader.svelte
+++ b/src/lib/components/announcements/AnnouncementHeader.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { operationStore, query } from '@urql/svelte';
+  import { AnnouncementImportance, GetAnnouncementsDocument } from '$lib/generated';
+  import AnnouncementRow from './AnnouncementRow.svelte';
+
+  const announcements = operationStore(GetAnnouncementsDocument, {});
+  query($announcements);
+</script>
+
+{#if $announcements.fetching}
+  <!-- Display nothing, don't disrupt the page for no reason -->
+{:else if $announcements.error}
+  <AnnouncementRow
+    message="Failed to load announcements: {$announcements.error.message}"
+    importance={AnnouncementImportance.Warning} />
+{:else if $announcements && $announcements.data && $announcements.data.getAnnouncements}
+  {#each $announcements?.data?.getAnnouncements as announcement}
+    <AnnouncementRow message={announcement.message} importance={announcement.importance} />
+  {/each}
+{/if}
+
+<style></style>

--- a/src/lib/components/announcements/AnnouncementHeader.svelte
+++ b/src/lib/components/announcements/AnnouncementHeader.svelte
@@ -14,9 +14,11 @@
     message="Failed to load announcements: {$announcements.error.message}"
     importance={AnnouncementImportance.Warning} />
 {:else if $announcements && $announcements.data && $announcements.data.getAnnouncements}
-  {#each $announcements?.data?.getAnnouncements as announcement}
-    <AnnouncementRow message={announcement.message} importance={announcement.importance} />
-  {/each}
+  <div class="max-h-96 overflow-y-scroll">
+    {#each $announcements?.data?.getAnnouncements as announcement}
+      <AnnouncementRow message={announcement.message} importance={announcement.importance} />
+    {/each}
+  </div>
 {/if}
 
 <style></style>

--- a/src/lib/components/announcements/AnnouncementRow.svelte
+++ b/src/lib/components/announcements/AnnouncementRow.svelte
@@ -14,12 +14,33 @@
     [AnnouncementImportance.Warning]: 'bg-yellow-400',
     [AnnouncementImportance.Fix]: 'bg-orange-600'
   };
+  const monospacePrefix = 'monotext:';
 
   export let message: string;
   export let importance: AnnouncementImportance;
+
+  // Enables making monospace announcements
+  $: isMonospace = message.startsWith(monospacePrefix);
+  $: finalMessage = isMonospace ? message.replaceAll(monospacePrefix, '') : message;
 </script>
 
-<div class="p-1 {backgroundColors[importance]}">
-  <Icon class="material-icons text-2xl align-middle">{iconNames[importance]}</Icon>
-  <span class="align-middle text-l"><b>{importance}:</b> {message}</span>
+<div class="{backgroundColors[importance]} max-h-64 overflow-hidden">
+  <div class="p-1 striped">
+    <Icon class="material-icons text-2xl align-middle">{iconNames[importance]}</Icon>
+    <div class="align-middle text-l inline-block whitespace-pre" class:font-mono={isMonospace}>
+      <b>{importance}: </b>{finalMessage}
+    </div>
+  </div>
 </div>
+
+<style>
+  .striped {
+    background: repeating-linear-gradient(
+      45deg,
+      transparent,
+      transparent 14px,
+      rgba(60, 60, 60, 0.1) 14px,
+      rgba(60, 60, 60, 0.1) 28px
+    );
+  }
+</style>

--- a/src/lib/components/announcements/AnnouncementRow.svelte
+++ b/src/lib/components/announcements/AnnouncementRow.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import { AnnouncementImportance } from '$lib/generated';
+  import { Icon } from '@smui/icon-button';
+
+  const iconNames: { [key in AnnouncementImportance]: string } = {
+    [AnnouncementImportance.Info]: 'info',
+    [AnnouncementImportance.Alert]: 'error',
+    [AnnouncementImportance.Warning]: 'warning',
+    [AnnouncementImportance.Fix]: 'build_circle'
+  };
+  const backgroundColors: { [key in AnnouncementImportance]: string } = {
+    [AnnouncementImportance.Info]: 'bg-sky-500',
+    [AnnouncementImportance.Alert]: 'bg-red-600',
+    [AnnouncementImportance.Warning]: 'bg-yellow-400',
+    [AnnouncementImportance.Fix]: 'bg-orange-600'
+  };
+
+  export let message: string;
+  export let importance: AnnouncementImportance;
+</script>
+
+<div class="p-1 {backgroundColors[importance]}">
+  <Icon class="material-icons text-2xl align-middle">{iconNames[importance]}</Icon>
+  <span class="align-middle text-l"><b>{importance}:</b> {message}</span>
+</div>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -133,7 +133,6 @@
 
 <div class="app-container">
   <TopAppBar variant="static">
-    <AnnouncementHeader />
     <Row>
       <Section>
         {#if drawerVariant === 'modal'}
@@ -202,6 +201,8 @@
         </Section>
       {/if}
     </Row>
+
+    <AnnouncementHeader />
   </TopAppBar>
 
   <div class="drawer-container">

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -40,6 +40,7 @@
   import { onMount } from 'svelte';
   import { customProtocolCheck, hasLauncher, pingLauncher } from '$lib/stores/launcher';
   import Sidebar from '$lib/components/general/Sidebar.svelte';
+  import AnnouncementHeader from '$lib/components/announcements/AnnouncementHeader.svelte';
 
   let root: HTMLElement;
   onMount(async () => {
@@ -132,6 +133,7 @@
 
 <div class="app-container">
   <TopAppBar variant="static">
+    <AnnouncementHeader />
     <Row>
       <Section>
         {#if drawerVariant === 'modal'}


### PR DESCRIPTION
Adds announcements to the top of all pages, with different colors and icons for each level of announcement. If announcements fail to fetch, displays a warning announcement.

Definitely open for feedback on colors, icons, and sizing, I'm not sure how accessible it is right now

![image](https://user-images.githubusercontent.com/96402405/180625893-25773c46-10fe-4f3a-a669-f26b324de249.png)

Also works well on mobile

![image](https://user-images.githubusercontent.com/96402405/180625896-c7da5aee-f663-4943-abfe-2212060961de.png)
