### PR TITLE
fix: various announcement tweaks

### DIFF
--- a/src/lib/components/announcements/AnnouncementHeader.svelte
+++ b/src/lib/components/announcements/AnnouncementHeader.svelte
@@ -14,7 +14,7 @@
     message="Failed to load announcements: {$announcements.error.message}"
     importance={AnnouncementImportance.Warning} />
 {:else if $announcements && $announcements.data && $announcements.data.getAnnouncements}
-  <div class="max-h-96 overflow-y-scroll">
+  <div class="max-h-96 overflow-y-auto">
     {#each $announcements?.data?.getAnnouncements as announcement}
       <AnnouncementRow message={announcement.message} importance={announcement.importance} />
     {/each}

--- a/src/lib/components/announcements/AnnouncementRow.svelte
+++ b/src/lib/components/announcements/AnnouncementRow.svelte
@@ -12,7 +12,7 @@
     [AnnouncementImportance.Info]: 'bg-sky-500',
     [AnnouncementImportance.Alert]: 'bg-red-600',
     [AnnouncementImportance.Warning]: 'bg-yellow-400',
-    [AnnouncementImportance.Fix]: 'bg-orange-600'
+    [AnnouncementImportance.Fix]: 'bg-green-600'
   };
   const monospacePrefix = 'monotext:';
 
@@ -25,9 +25,12 @@
 </script>
 
 <div class="{backgroundColors[importance]} max-h-64 overflow-hidden">
-  <div class="p-1 striped">
+  <div class="p-1 striped text-black">
     <Icon class="material-icons text-2xl align-middle">{iconNames[importance]}</Icon>
-    <div class="align-middle text-l inline-block whitespace-pre" class:font-mono={isMonospace}>
+    <div
+      class="align-middle text-l inline-block break-words max-w-full"
+      class:font-mono={isMonospace}
+      class:whitespace-pre={isMonospace}>
       <b>{importance}: </b>{finalMessage}
     </div>
   </div>

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -201,8 +201,6 @@
         </Section>
       {/if}
     </Row>
-
-    <AnnouncementHeader />
   </TopAppBar>
 
   <div class="drawer-container">
@@ -212,8 +210,9 @@
       <Scrim fixed={false} />
     {/if}
 
-    <AppContent class="app-content w-full overflow-auto py-6 px-3">
-      <main class="main-content min-h-full">
+    <AppContent class="app-content w-full overflow-auto">
+      <AnnouncementHeader />
+      <main class="main-content min-h-100% py-6 px-3">
         <slot />
       </main>
     </AppContent>


### PR DESCRIPTION
fix: changes the 'fix' announcement from orange to green
fix: removes the scrollbar from announcements that can't scroll
fix: fixes word wrapping
feat: moves the announcement header inside the page content, allowing
      it to scroll and making it less obtrusive