### PR TITLE
Compatibility info

### DIFF
--- a/src/lib/components/mods/compatibility/CompatibilityButton.svelte
+++ b/src/lib/components/mods/compatibility/CompatibilityButton.svelte
@@ -9,22 +9,20 @@
   export let compatibility: CompatibilityInfoInput;
 </script>
 
-{#if compatibility}
-  <Button
-    --mdc-text-button-container-height="20px"
-    class="min-w-0 m-0"
-    title="Compatibility information"
-    on:click={() => {
-      open = true;
-    }}>
-    <CompatibilityIcon compatibility={compatibility.EA} />
-    <CompatibilityIcon compatibility={compatibility.EXP} EXP={true} />
-  </Button>
+<Button
+  --mdc-text-button-container-height="20px"
+  class="min-w-0 m-0"
+  title="Compatibility information (click to view more info)"
+  on:click={() => {
+    open = true;
+  }}>
+  <CompatibilityIcon compatibility={compatibility?.EA} />
+  <CompatibilityIcon compatibility={compatibility?.EXP} EXP={true} />
+</Button>
 
-  <Dialog bind:open>
-    <Title>Compatibility Information</Title>
-    <Content>
-      <CompatibilityInfo {compatibility} />
-    </Content>
-  </Dialog>
-{/if}
+<Dialog bind:open>
+  <Title>Compatibility Information</Title>
+  <Content>
+    <CompatibilityInfo {compatibility} />
+  </Content>
+</Dialog>

--- a/src/lib/components/mods/compatibility/CompatibilityIcon.svelte
+++ b/src/lib/components/mods/compatibility/CompatibilityIcon.svelte
@@ -2,7 +2,7 @@
   import type { CompatibilityInput } from '$lib/generated';
   import { CompatibilityState } from '$lib/generated';
 
-  export let compatibility!: CompatibilityInput;
+  export let compatibility: CompatibilityInput;
   export let EXP = false;
   let iconText = 'rocket_launch';
   if (EXP) {
@@ -12,8 +12,9 @@
 
 <p
   class="material-icons text-base"
-  class:mod-state-works={compatibility.state === CompatibilityState.Works}
-  class:mod-state-damaged={compatibility.state === CompatibilityState.Damaged}
-  class:mod-state-broken={compatibility.state === CompatibilityState.Broken}>
+  class:mod-state-works={compatibility?.state === CompatibilityState.Works}
+  class:mod-state-damaged={compatibility?.state === CompatibilityState.Damaged}
+  class:mod-state-broken={compatibility?.state === CompatibilityState.Broken}
+  class:mod-state-unknown={!compatibility}>
   {iconText}
 </p>

--- a/src/lib/components/mods/compatibility/CompatibilityInfo.svelte
+++ b/src/lib/components/mods/compatibility/CompatibilityInfo.svelte
@@ -4,10 +4,31 @@
   import { markdown } from '../../../utils/markdown';
 
   export let compatibility: CompatibilityInfoInput;
+  export const compatibilityStateDescriptions: {
+    [key: string]: string;
+  } = {
+    Works: 'The mod should be functioning as intended.',
+    Damaged:
+      'Something is causing the mod to work improperly, but it is partially working. Be sure to read the note and see an explanation of what is going wrong!',
+    Broken:
+      'The mod is suffering from a critical problem and could do things like crash your game at launch if you were to install it. Be sure to read the note and see an explanation of what is going wrong!',
+    Unknown:
+      'No compatibility information has been reported for this mod yet. Try it out and contact us on the Discord so it can be updated!'
+  };
 </script>
 
+<div>
+  Compatibility information is maintained by the community. If you encounter issues with a mod, please report it on the <a
+    href="https://discord.gg/xkVJ73E"
+    style="text-decoration: underline">Discord</a
+  >!
+</div>
+<br />
 {#if compatibility}
-  <div>Early Access: <CompatibilityStateText state={compatibility.EA.state} /></div>
+  <div>Early Access: <CompatibilityStateText state={compatibility?.EA?.state} /></div>
+  <div class="compatibility-state-description">
+    {compatibilityStateDescriptions[compatibility?.EA?.state || 'Unknown']}
+  </div>
   {#if compatibility.EA.note}
     <div>
       Note: {#await markdown(compatibility.EA.note) then rendered}
@@ -15,7 +36,10 @@
       {/await}
     </div>
   {/if}
-  <div>Experimental: <CompatibilityStateText state={compatibility.EXP.state} /></div>
+  <div>Experimental: <CompatibilityStateText state={compatibility?.EXP?.state} /></div>
+  <div class="compatibility-state-description">
+    {compatibilityStateDescriptions[compatibility?.EXP?.state || 'Unknown']}
+  </div>
   {#if compatibility.EXP.note}
     <div>
       Note: {#await markdown(compatibility.EXP.note) then rendered}
@@ -23,4 +47,8 @@
       {/await}
     </div>
   {/if}
+{:else}
+  <div>
+    {compatibilityStateDescriptions.Unknown}
+  </div>
 {/if}

--- a/src/routes/_global.postcss
+++ b/src/routes/_global.postcss
@@ -227,6 +227,14 @@ body.accessibility {
   color: red;
 }
 
+.mod-state-unknown {
+  color: grey;
+}
+
+.compatibility-state-description {
+  font-style: italic;
+}
+
 @media (min-width: 1279px) {
   .grid-auto-max {
     grid-template-columns: minmax(0, 100%) fit-content(30%);


### PR DESCRIPTION
Instead of displaying nothing for mods without compatibility info, display gray icons
![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/9c20872a-cb20-4d44-8f1c-90e8d50ffe1e)

Explain the purpose of each compatibility status, and include header text about what they're from
![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/3ba2f33f-9d4b-4231-a1c0-8d2c07427f76)

A special message for mods with no compatibility info:
![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/f55947dc-8ae3-4225-9564-d99ece3927cd)

closes #69 