### PR TITLE
fix: mod grid orderBy search getting overriden by Select and not being set using URL params

### DIFF
--- a/src/lib/components/mods/ModGrid.svelte
+++ b/src/lib/components/mods/ModGrid.svelte
@@ -29,6 +29,10 @@
   let order: Order = Order.Desc;
   let orderBy: ModFields = ModFields.LastVersionDate;
 
+  if (search) {
+    orderBy = ModFields.Search;
+  }
+
   let page = parseInt($storePage.url.searchParams.get('p'), 10) || 1;
 
   $: mods = queryStore({


### PR DESCRIPTION
`orderBy` was getting overriden by Select when set to `search`, because Select would then lookup the value in the Options to update the `selectedIndex`, but end up with `-1`, and set `orderBy` to null/undefined.
This was causing the mods query to be sent with `order=desc`, but without `orderBy`, which returned an internal server error ([report on discord](https://discord.com/channels/555424930502541343/555516979260293132/1127964099209342986)).
There are two solutions for this: this PR's, and delaying setting `orderBy` by one tick, giving Select time to receive the updated `Options`, but the latter would trigger two separate API requests.

Additionally, the order is set to `search` on page load, if the search URL parameter is present.