### PR TITLE
fix: pagination reactivity and total pages being 0 during fetches

### DIFF
--- a/src/lib/components/guides/GuideGrid.svelte
+++ b/src/lib/components/guides/GuideGrid.svelte
@@ -16,7 +16,7 @@
   // TODO Selectable
   const perPage = 40;
 
-  const page = 1;
+  let page = 1;
 
   $: guides = queryStore({
     query: GetGuidesDocument,
@@ -24,8 +24,10 @@
     variables: { offset: (page - 1) * perPage, limit: perPage }
   });
 
-  let totalGuides: number;
-  $: totalGuides = $guides?.data?.getGuides?.count || 0;
+  let totalGuides = 0;
+  $: if ($guides?.data?.getGuides?.count) {
+    totalGuides = $guides.data.getGuides.count;
+  }
 
   $: gridClasses =
     colCount == 4

--- a/src/lib/components/mods/ModGrid.svelte
+++ b/src/lib/components/mods/ModGrid.svelte
@@ -41,7 +41,7 @@
     variables: { offset: (page - 1) * perPage, limit: perPage, search, order, orderBy }
   });
 
-  let totalMods: number;
+  let totalMods = 0;
 
   let searchField = search;
 
@@ -73,7 +73,9 @@
     goto(url.toString(), { keepFocus: true });
   }
 
-  $: totalMods = $mods?.data?.getMods?.count || 0;
+  $: if ($mods?.data?.getMods?.count) {
+    totalMods = $mods.data.getMods.count;
+  }
 
   $: gridClasses =
     colCount == 4

--- a/src/routes/admin/sml-versions/+page.svelte
+++ b/src/routes/admin/sml-versions/+page.svelte
@@ -14,7 +14,7 @@
   // TODO Selectable
   const perPage = 20;
 
-  const page = 1;
+  let page = 1;
 
   $: versions = queryStore({
     query: GetSmlVersionsAdminDocument,
@@ -27,7 +27,10 @@
     }
   });
 
-  $: totalVersions = $versions?.data?.getSMLVersions?.count;
+  let totalVersions = 0;
+  $: if ($versions?.data?.getSMLVersions?.count) {
+    totalVersions = $versions.data.getSMLVersions.count;
+  }
 
   const deleteVersion = (smlVersionID: string) => {
     client

--- a/src/routes/admin/unapproved-mods/+page.svelte
+++ b/src/routes/admin/unapproved-mods/+page.svelte
@@ -14,7 +14,7 @@
   // TODO Selectable
   const perPage = 20;
 
-  const page = 1;
+  let page = 1;
 
   $: mods = queryStore({
     query: GetUnapprovedModsDocument,
@@ -27,7 +27,10 @@
     }
   });
 
-  $: totalMods = $mods?.data?.getUnapprovedMods?.count;
+  let totalMods = 0;
+  $: if ($mods?.data?.getUnapprovedMods?.count) {
+    totalMods = $mods.data.getUnapprovedMods.count;
+  }
 
   const approveMod = (modId: string) => {
     client

--- a/src/routes/admin/unapproved-versions/+page.svelte
+++ b/src/routes/admin/unapproved-versions/+page.svelte
@@ -15,7 +15,7 @@
   // TODO Selectable
   const perPage = 20;
 
-  const page = 1;
+  let page = 1;
 
   $: versions = queryStore({
     query: GetUnapprovedVersionsDocument,
@@ -28,7 +28,10 @@
     }
   });
 
-  $: totalVersions = $versions?.data?.getUnapprovedVersions?.count;
+  let totalVersions = 0;
+  $: if ($versions?.data?.getUnapprovedVersions?.count) {
+    totalVersions = $versions.data.getUnapprovedVersions.count;
+  }
 
   const approveVersion = (versionId: string) => {
     client

--- a/src/routes/sml-versions/+page.svelte
+++ b/src/routes/sml-versions/+page.svelte
@@ -16,7 +16,7 @@
   // TODO Selectable
   const perPage = 20;
 
-  const page = 1;
+  let page = 1;
 
   // TODO Pagination
   $: versions = queryStore({
@@ -28,7 +28,10 @@
     }
   });
 
-  $: totalVersions = $versions?.data?.getSMLVersions?.count;
+  let totalVersions = 0;
+  $: if ($versions?.data?.getSMLVersions?.count) {
+    totalVersions = $versions.data.getSMLVersions.count;
+  }
 
   const toggleRow = (versionId: string) => {
     if (expandedVersions.has(versionId)) {


### PR DESCRIPTION
During the framework upgrade and replacing some `writable`s with reactive properties, the updated properties were not bound to.

With the changes to urql, query store data is undefined during fetching, so totals could not be simply computed variables set to the query data count value. They are now variables and only updated when the data is defined.