### PR TITLE
chore: address a11y warnings

### DIFF
--- a/src/lib/components/general/FicsitCard.svelte
+++ b/src/lib/components/general/FicsitCard.svelte
@@ -41,7 +41,7 @@
     class:text-gray-500={fake}
     class:font-flow={fake}
     class="grid grid-max-auto sm:grid-cols-2 grid-cols-1 justify-items-center">
-    <div class="cursor-pointer card-image-container" on:click={() => goto(link)}>
+    <div class="cursor-pointer card-image-container" on:click={() => goto(link)} on:keypress={() => goto(link)}>
       {#if fake}
         <div class="bg-gray-500 logo min-w-full min-h-full max-w-full max-h-full" />
       {:else}

--- a/src/lib/components/mods/ModVersions.svelte
+++ b/src/lib/components/mods/ModVersions.svelte
@@ -73,6 +73,9 @@
                 class="grid grid-flow-col gap-4"
                 on:click|stopPropagation={() => {
                   /*block table row expansion*/
+                }}
+                on:keypress|stopPropagation={() => {
+                  /*a11y-click-events-have-key-events*/
                 }}>
                 <Button variant="outlined" href={base + '/mod/' + modId + '/version/' + version.id}
                   >{$t('view')}</Button>

--- a/src/lib/components/utils/TagList.svelte
+++ b/src/lib/components/utils/TagList.svelte
@@ -176,8 +176,10 @@
           <div class="text-neutral-300 whitespace-nowrap flex removable-tag">
             <span class="hashtag text-orange-500">#</span>
             <span class="cancel">
-              <i class="material-icons mdc-chip__icon mdc-chip__icon--trailing" on:click={() => deleteTag(tag)}
-                >cancel</i>
+              <i
+                class="material-icons mdc-chip__icon mdc-chip__icon--trailing"
+                on:click={() => deleteTag(tag)}
+                on:keypress={() => deleteTag(tag)}>cancel</i>
             </span>
             <p>{tag.name}</p>
           </div>


### PR DESCRIPTION
Not sure how to test thoroughly
1. As far as I know FicsitCard's image element can never gain focus keydown never applies
2. I don't have tags access to test TagList with
3. ModVersions table element seems to be unaffected?