### PR TITLE
fix: route params reactivity, graphql client token, mod grid navigation

### DIFF
--- a/src/lib/components/auth/LoginDialog.svelte
+++ b/src/lib/components/auth/LoginDialog.svelte
@@ -22,14 +22,6 @@
   const client = getContextClient();
 
   if (browser) {
-    const getMe = queryStore({
-      query: GetMeDocument,
-      client,
-      variables: {},
-      requestPolicy: 'network-only',
-      pause: true
-    });
-
     let first = true;
     userToken.subscribe((token) => {
       if (token) {
@@ -53,21 +45,17 @@
       first = false;
 
       if (token) {
-        getMe.pause();
-        getMe.resume();
-
-        const unsub = getMe.subscribe((response) => {
-          if (!response.fetching) {
+        client
+          .query(GetMeDocument, {}, { requestPolicy: 'network-only' })
+          .toPromise()
+          .then((response) => {
             if (response.error) {
               // TODO Toast or something
               console.error(response.error.message);
-              unsub();
             } else if (response.data) {
               user.set(response.data.getMe);
-              unsub();
             }
-          }
-        });
+          });
       } else {
         user.set(null);
       }

--- a/src/lib/components/mods/ModGrid.svelte
+++ b/src/lib/components/mods/ModGrid.svelte
@@ -68,6 +68,12 @@
 
   let urlSearch = searchField;
 
+  $: if ($navigating && $navigating.type !== 'goto') {
+    searchField = $storePage.url.searchParams.get('q');
+    page = parseInt($storePage.url.searchParams.get('p'), 10) || 1;
+    urlSearch = searchField;
+  }
+
   const updateUrl = () => {
     if (browser && !$navigating) {
       const url = new URL(window.location.origin + window.location.pathname);

--- a/src/lib/components/mods/ModGrid.svelte
+++ b/src/lib/components/mods/ModGrid.svelte
@@ -10,7 +10,7 @@
   import Fab from '@smui/fab';
   import { Icon } from '@smui/common';
   import { goto } from '$app/navigation';
-  import { page as storePage } from '$app/stores';
+  import { page as storePage, navigating } from '$app/stores';
   import { user } from '$lib/stores/user';
   import FicsitCard from '$lib/components/general/FicsitCard.svelte';
   import Select, { Option } from '@smui/select';
@@ -66,12 +66,28 @@
     }, 250) as unknown as number;
   }
 
-  $: if (browser) {
-    const url = new URL(window.location.origin + window.location.pathname);
-    url.searchParams.append('p', page.toString());
-    searchField !== '' && searchField !== null && url.searchParams.append('q', searchField);
-    goto(url.toString(), { keepFocus: true });
+  let urlSearch = searchField;
+
+  const updateUrl = () => {
+    if (browser && !$navigating) {
+      const url = new URL(window.location.origin + window.location.pathname);
+      url.searchParams.append('p', page.toString());
+      urlSearch !== '' && urlSearch !== null && url.searchParams.append('q', urlSearch);
+      goto(url.toString(), { keepFocus: true });
+    }
+  };
+
+  $: {
+    page;
+    urlSearch;
+    updateUrl();
   }
+
+  const handleKeyDown = (event: CustomEvent | KeyboardEvent) => {
+    if ((event as KeyboardEvent).key === 'Enter') {
+      urlSearch = searchField;
+    }
+  };
 
   $: if ($mods?.data?.getMods?.count) {
     totalMods = $mods.data.getMods.count;
@@ -119,9 +135,9 @@
       </div>
       <Paper class="search-paper mr-3" elevation={6}>
         <Icon class="material-icons">search</Icon>
-        <Input bind:value={searchField} placeholder="Search" />
+        <Input bind:value={searchField} on:keypress={handleKeyDown} placeholder="Search" />
       </Paper>
-      <Fab on:click={() => goto(base + '/mods?q=' + search)} color="primary" mini class="solo-fab" aria-label="Search">
+      <Fab on:click={() => (urlSearch = searchField)} color="primary" mini class="solo-fab" aria-label="Search">
         <Icon class="material-icons">arrow_forward</Icon>
       </Fab>
     </div>

--- a/src/lib/core/graphql.ts
+++ b/src/lib/core/graphql.ts
@@ -84,22 +84,19 @@ export const initializeGraphQLClient = (fetch?: LoadEvent['fetch']): Client =>
           }
         }
       }),
-      authExchange(async (utils) => {
-        const token = get(userToken);
-        return {
-          addAuthToOperation(operation) {
-            return utils.appendHeaders(operation, {
-              Authorization: token
-            });
-          },
-          didAuthError(error) {
-            return error.message.indexOf('user not logged in') >= 0;
-          },
-          async refreshAuth() {
-            // Token cannot be refreshed currently
-          }
-        };
-      }),
+      authExchange(async (utils) => ({
+        addAuthToOperation(operation) {
+          return utils.appendHeaders(operation, {
+            Authorization: get(userToken)
+          });
+        },
+        didAuthError(error) {
+          return error.message.indexOf('user not logged in') >= 0;
+        },
+        async refreshAuth() {
+          // Token cannot be refreshed currently
+        }
+      })),
       persistedExchange({
         preferGetForPersistedQueries: true
       }),

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,7 +12,7 @@
 
   export let data: PageData;
 
-  const { mods } = data;
+  $: ({ mods } = data);
 
   export const { t } = getTranslate();
 

--- a/src/routes/admin/sml-versions/[smlVersionId]/edit/+page.svelte
+++ b/src/routes/admin/sml-versions/[smlVersionId]/edit/+page.svelte
@@ -12,7 +12,7 @@
 
   export let data: PageData;
 
-  const { smlVersionId } = data;
+  $: ({ smlVersionId } = data);
 
   const client = getContextClient();
 

--- a/src/routes/guide/[guideId]/+page.svelte
+++ b/src/routes/guide/[guideId]/+page.svelte
@@ -17,7 +17,7 @@
 
   export let data: PageData;
 
-  const { guideId, guide } = data;
+  $: ({ guideId, guide } = data);
 
   const client = getContextClient();
 

--- a/src/routes/guide/[guideId]/edit/+page.svelte
+++ b/src/routes/guide/[guideId]/edit/+page.svelte
@@ -12,7 +12,7 @@
 
   export let data: PageData;
 
-  const { guideId } = data;
+  $: ({ guideId } = data);
 
   const client = getContextClient();
 

--- a/src/routes/mod/[modId]/+page.svelte
+++ b/src/routes/mod/[modId]/+page.svelte
@@ -21,7 +21,7 @@
 
   export let data: PageData;
 
-  const { modId, mod } = data;
+  $: ({ modId, mod } = data);
 
   const client = getContextClient();
 

--- a/src/routes/mod/[modId]/edit/+page.svelte
+++ b/src/routes/mod/[modId]/edit/+page.svelte
@@ -13,7 +13,7 @@
 
   export let data: PageData;
 
-  const { modId } = data;
+  $: ({ modId } = data);
 
   const client = getContextClient();
 

--- a/src/routes/mod/[modId]/new-version/+page.svelte
+++ b/src/routes/mod/[modId]/new-version/+page.svelte
@@ -15,7 +15,7 @@
 
   export let data: PageData;
 
-  const { modId } = data;
+  $: ({ modId } = data);
 
   const client = getContextClient();
 

--- a/src/routes/mod/[modId]/version/[versionId]/+page.svelte
+++ b/src/routes/mod/[modId]/version/[versionId]/+page.svelte
@@ -17,7 +17,7 @@
 
   export let data: PageData;
 
-  const { modId, versionId, version } = data;
+  $: ({ modId, versionId, version } = data);
 
   const client = getContextClient();
 

--- a/src/routes/mod/[modId]/version/[versionId]/edit/+page.svelte
+++ b/src/routes/mod/[modId]/version/[versionId]/edit/+page.svelte
@@ -12,7 +12,7 @@
 
   export let data: PageData;
 
-  const { modId, versionId } = data;
+  $: ({ modId, versionId } = data);
 
   const client = getContextClient();
 

--- a/src/routes/user/[userId]/+page.svelte
+++ b/src/routes/user/[userId]/+page.svelte
@@ -11,7 +11,7 @@
 
   export let data: PageData;
 
-  const { user } = data;
+  $: ({ user } = data);
 
   let guidesTab = false;
 </script>


### PR DESCRIPTION
The PageData values were not obtained reactively, so when the rendered route was reused (such as navigating to the same route format as the currently displayed page), the data displayed was not updated. This was missed during the framework upgrade.

The graphql client authExhchange was not getting the user token on every query, but rather using the one that was set when the client was created. This resulted in the auth not being applied until a full page reload.

Replaced an unnecessary queryStore for getMe in LoginDialog that was only run once with `client.query(...)`.

The mods page URL params were updated on every keypress, which resulted in navigation backwards and forwards navigating one character at a time.

Navigating on the mods page did not update the page and search variables.