### PR TITLE
fix: user page getting incomplete mod data

### DIFF
--- a/src/gql/users/user.graphql
+++ b/src/gql/users/user.graphql
@@ -40,6 +40,10 @@ query GetUser($user: UserID!) {
             note
           }
         }
+        tags {
+          id
+          name
+        }
       }
     }
     guides {


### PR DESCRIPTION
The tags were missing from the user query and therefore the ModCards were passing `undefined` to the TagList, which caused the whole page to error.

Using fragments for the information a component requires would help in avoiding this in the future.

Enabling strict null checking would also improve the type safety of the code in this regard. There are many places using optional chaining already, without marking the variable as allowing undefined/null, making these issues harder to spot.

If strict null check is enabled, graphql-codegen should also be configured with 
```yml
avoidOptionals:
        object: true
        field: true
```

Both of these suggestions are outside the scope of this hot-fix PR, but good to have written down for the future.