### PR TITLE
fix: display 'Unknown' instead of nothing when compatibility state is missing

### DIFF
--- a/src/lib/components/mods/compatibility/CompatibilityStateText.svelte
+++ b/src/lib/components/mods/compatibility/CompatibilityStateText.svelte
@@ -9,8 +9,6 @@
   const classForState = (s: CompatibilityState): string => `mod-state-${s.toString().toLowerCase()}`;
 </script>
 
-{#if state}
-  <p class="{classForState(textForState)} mod-state">
-    {$t(`compatibility-info.state.${textForState.toString().toLowerCase()}`)}
-  </p>
-{/if}
+<p class="{classForState(textForState)} mod-state">
+  {$t(`compatibility-info.state.${textForState.toString().toLowerCase()}`)}
+</p>


### PR DESCRIPTION
Before:
![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/552ee260-4405-4df1-8c86-38827c3d59de)

After:
![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/3d97e875-cad4-4aa1-8df5-f23b98144f4d)
