### PR TITLE
feat: display warning on unapproved versions

### DIFF
--- a/src/gql/versions/mod_version.graphql
+++ b/src/gql/versions/mod_version.graphql
@@ -10,6 +10,7 @@ query GetModVersion($version: VersionID!) {
     link
     hash
     size
+    approved
     targets {
       targetName
       link

--- a/src/lib/components/versions/VersionDescription.svelte
+++ b/src/lib/components/versions/VersionDescription.svelte
@@ -1,16 +1,28 @@
 <script lang="ts">
+  import { AnnouncementImportance } from '$lib/generated';
   import { markdown } from '$lib/utils/markdown';
+  import AnnouncementRow from '../announcements/AnnouncementRow.svelte';
 
   export let changelog!: string;
+  export let approved: boolean;
 </script>
 
-<div class="h-fit card p-4">
-  <section>
-    <div class="markdown-content">
-      {#await markdown(changelog) then changelogRendered}
-        <!-- eslint-disable -->
-        <p>{@html changelogRendered}</p>
-      {/await}
+<div>
+  {#if !approved}
+    <div class="p-4">
+      <AnnouncementRow
+        importance={AnnouncementImportance.Warning}
+        message="This version has not yet been approved by the virus scanner and is hidden until this process is complete. If this message isn't gone in the next few minutes, ask for manual approval on the Discord." />
     </div>
-  </section>
+  {/if}
+  <div class="h-fit card p-4">
+    <section>
+      <div class="markdown-content break-words">
+        {#await markdown(changelog) then changelogRendered}
+          <!-- eslint-disable -->
+          <p>{@html changelogRendered}</p>
+        {/await}
+      </div>
+    </section>
+  </div>
 </div>

--- a/src/routes/mod/[modId]/version/[versionId]/+page.svelte
+++ b/src/routes/mod/[modId]/version/[versionId]/+page.svelte
@@ -142,7 +142,7 @@
       </div>
     </div>
     <div class="grid grid-auto-max auto-cols-fr gap-4">
-      <VersionDescription changelog={$version.data.getVersion.changelog} />
+      <VersionDescription changelog={$version.data.getVersion.changelog} approved={$version.data.getVersion.approved} />
       <div class="grid grid-cols-1 auto-rows-min gap-8">
         <VersionInfo version={$version.data.getVersion} />
         <VersionTargetSupportGrid targets={$version.data.getVersion.targets} />


### PR DESCRIPTION
Also add `break-words` to version descriptions (not sure why it wasn't there yet)

![image](https://github.com/satisfactorymodding/smr-frontend/assets/25965766/f5bbaf04-becb-4678-9882-785930d8f908)
