### PR TITLE
Obfuscate discord invite to prevent web scraping

### DIFF
--- a/src/lib/components/general/Sidebar.svelte
+++ b/src/lib/components/general/Sidebar.svelte
@@ -42,7 +42,7 @@
       label: $t('sidebar.tools')
     },
     {
-      url: 'https://discord.gg/xkVJ73E',
+      url: 'https://discord.ficsit.app',
       icon: 'people',
       label: $t('discord'),
       external: true


### PR DESCRIPTION
Now that we have discord.ficsit.app, we can redirect to whatever invite we want. SInce we're having spam issues from bots that are potentially scraping the invite off the front page, let's just use the redirecting link instead.

I would also recommend that we revoke the current invite entirely and get it changed. We can give the official community discord.ficsit.app as well.