### PR TITLE
feat: remove mod stability info from display (due to be replaced)

### DIFF
--- a/src/lib/components/mods/ModLatestVersions.svelte
+++ b/src/lib/components/mods/ModLatestVersions.svelte
@@ -18,9 +18,7 @@
   };
 
   const stabilities = {
-    release: 'new_releases',
-    beta: 'warning',
-    alpha: 'report'
+    release: 'new_releases'
   };
 
   export let latestVersions!: ILatestVersions;
@@ -44,8 +42,7 @@
               <a
                 href="{base}/mod/{modId}/version/{latestVersions[stability].id}/"
                 class="text-yellow-500 underline"
-                title="Click to view patch notes for this version"
-                >Version {latestVersions[stability].version} ({stability})</a>
+                title="Click to view patch notes for this version">Version {latestVersions[stability].version}</a>
               <div>{prettyDate(latestVersions[stability].created_at)}</div>
             </div>
             <div class="text-1xl col-span-3 h-auto w-auto p-2.5">

--- a/src/lib/components/mods/ModVersions.svelte
+++ b/src/lib/components/mods/ModVersions.svelte
@@ -49,7 +49,6 @@
         <thead>
           <tr>
             <th>{$t('version')}</th>
-            <th>{$t('stability')}</th>
             <th>{$t('game-versions')}</th>
             <th>{$t('downloads')}</th>
             <th>{$t('upload-date')}</th>
@@ -60,7 +59,6 @@
           {#each $versions.data.getMod.versions as version}
             <tr on:click={() => toggleRow(version.id)}>
               <td>{version.version}</td>
-              <td>{version.stability}</td>
               <td>{version.game_version}</td>
               <td>{prettyNumber(version.downloads)}</td>
               <td>{prettyDate(version.created_at)}</td>

--- a/src/lib/components/versions/VersionForm.svelte
+++ b/src/lib/components/versions/VersionForm.svelte
@@ -44,20 +44,6 @@
 
 <form use:form>
   <div class="grid grid-flow-row gap-6">
-    <div class="grid grid-flow-row gap-2">
-      <label class="label">
-        <span>{$t('stability')} *</span>
-        <select class="select" bind:value={$data.stability}>
-          <option value="alpha">Alpha</option>
-          <option value="beta">Beta</option>
-          <option value="release">Release</option>
-        </select>
-      </label>
-      <ValidationMessage for="stability" let:messages={message}>
-        <span class="validation-message">{message || ''}</span>
-      </ValidationMessage>
-    </div>
-
     {#if !editing}
       <div class="grid grid-flow-row gap-2">
         <label for="file">{$t('file')} *</label>

--- a/src/lib/components/versions/VersionInfo.svelte
+++ b/src/lib/components/versions/VersionInfo.svelte
@@ -3,7 +3,7 @@
   import { prettyBytes, prettyDate, prettyNumber } from '$lib/utils/formatting';
   import { getTranslate } from '@tolgee/svelte';
 
-  export let version!: Pick<Version, 'created_at' | 'game_version' | 'size' | 'stability' | 'downloads' | 'hash'>;
+  export let version!: Pick<Version, 'created_at' | 'game_version' | 'size' | 'downloads' | 'hash'>;
 
   export const { t } = getTranslate();
 </script>
@@ -15,7 +15,6 @@
       <span><strong>{$t('entry.created-at')}:</strong> {prettyDate(version.created_at)}</span><br />
       <span><strong>{$t('downloads')}:</strong> {prettyNumber(version.downloads)}</span><br />
       <span><strong>{$t('game-versions')}:</strong> {version.game_version}</span><br />
-      <span><strong>{$t('stability')}:</strong> {version.stability}</span><br />
       <span><strong>{$t('size')}:</strong> {prettyBytes(version.size)}</span><br />
       <span><strong>{$t('hash')}:</strong> {version.hash}</span>
     </div>


### PR DESCRIPTION
bug: causes no Latest Version to display on mods with no `release` stability versions. Upon ficisit-api changes to remove stability (or the release of 1.0 mods which will automatically be `release` stability) this will become a non-issue