### PR TITLE
fix(modgrid): restore scroll position of modgrid after navigation

### DIFF
--- a/src/routes/mods/+page.svelte
+++ b/src/routes/mods/+page.svelte
@@ -1,6 +1,18 @@
 <script lang="ts">
   import ModGrid from '$lib/components/mods/ModGrid.svelte';
   import MetaDescriptors from '$lib/components/utils/MetaDescriptors.svelte';
+  import type { Snapshot } from './$types';
+
+  export const snapshot: Snapshot<{ left: number; top: number }> = {
+    capture: () => {
+      const page_div = document.getElementById('page');
+      return { left: page_div.scrollLeft, top: page_div.scrollTop };
+    },
+    restore: (snapshotObj) => {
+      const page_div = document.getElementById('page');
+      page_div.scrollTo(snapshotObj.left, snapshotObj.top);
+    }
+  };
 </script>
 
 <svelte:head>


### PR DESCRIPTION
Previously the scroll position of the modgrid would be reset when a user navigated back to the grid page. This is due to the scrolling setup, where `div#page` is scrolled rather than the complete page. That could probably be properly fixed in the future, but this works for now. Properly fixing this would likely resolve #156 and #183 as well.

Fixes #42