### PR TITLE
feat: add Satisfactory Interactive Map th.gl tool link

### DIFF
--- a/src/lib/components/general/FicsitCard.svelte
+++ b/src/lib/components/general/FicsitCard.svelte
@@ -87,7 +87,7 @@
           <div class="logo max-h-full min-h-full min-w-full max-w-full bg-neutral-500" />
         {:else}
           <img
-            class="logo absolute max-h-full min-h-full min-w-full max-w-full transition-opacity delay-100 duration-200 ease-linear"
+            class="logo absolute max-h-full min-h-full min-w-full max-w-full transition-opacity delay-100 duration-200 ease-linear object-contain"
             class:invisible={!imageLoaded}
             class:opacity-0={!imageLoaded}
             src={renderedLogo}

--- a/src/lib/components/general/FicsitCard.svelte
+++ b/src/lib/components/general/FicsitCard.svelte
@@ -87,7 +87,7 @@
           <div class="logo max-h-full min-h-full min-w-full max-w-full bg-neutral-500" />
         {:else}
           <img
-            class="logo absolute max-h-full min-h-full min-w-full max-w-full transition-opacity delay-100 duration-200 ease-linear object-contain"
+            class="logo absolute max-h-full min-h-full min-w-full max-w-full object-contain transition-opacity delay-100 duration-200 ease-linear"
             class:invisible={!imageLoaded}
             class:opacity-0={!imageLoaded}
             src={renderedLogo}

--- a/src/routes/tools/+page.svelte
+++ b/src/routes/tools/+page.svelte
@@ -6,6 +6,14 @@
   // cspell:ignore SatisGraphtory tehalexf thinkaliker Moritz
   const tools: Tool[] = [
     {
+      name: 'Satisfactory Interactive Map',
+      author: 'DevLeon',
+      logo: 'https://www.th.gl/satisfactory.jpg',
+      description:
+        'Explore Satisfactory 1.0 with this Interactive Map and In-Game App! Minimap, real-Time position tracking, full-text search, custom drawings, and more!',
+      link: 'https://satisfactory.th.gl/'
+    },
+    {
       name: 'Satisfactory Calculator Interactive Map (SCIM)',
       author: 'Anthor',
       logo: 'https://i.imgur.com/vPKmL9d.png',


### PR DESCRIPTION
This PR adds the Interactive Map available on https://satisfactory.th.gl/. There is a related In-Game Companion app too, but I think it's better to have a single entry:
https://www.overwolf.com/app/Leon_Machens-Satisfactory_Map

I am using a different logo aspect ratio and updated the img css for better fit.